### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Optional Packages:
 
 Additional packages are required for development and testing. See `requirements.txt` for a more complete list.
 
-Debian packages are available for pySerial, pytz, pythone-gevent, and python-openssl. They can be installed with : 
+Debian packages are available for pySerial, pytz, python-gevent, and python-openssl. They can be installed with : 
 
     sudo apt-get install git python-dev python-serial python-tz python-gevent python-openssl
 

--- a/pytomation/interfaces/arduino.py
+++ b/pytomation/interfaces/arduino.py
@@ -133,7 +133,7 @@ class Arduino(HAInterface):
         #self._interface.read(100)        
         		
     def _readInterface(self, lastPacketHash):
-        #check to see if there is anyting we need to read
+        #check to see if there is anything we need to read
         responses = self._interface.read()
         if len(responses) != 0:
             for response in responses.split():
@@ -172,7 +172,7 @@ class Arduino(HAInterface):
     def _processRegister(self, response, lastPacketHash):
         foundCommandHash = None
 
-        #find our pending command in the list so we can say that we're done (if we are running in syncronous mode - if not well then the caller didn't care)
+        #find our pending command in the list so we can say that we're done (if we are running in synchronous mode - if not well then the caller didn't care)
         for (commandHash, commandDetails) in self._pendingCommandDetails.items():
             if commandDetails['modemCommand'] == self._modemCommands['read_register']:
                 #Looks like this is our command.  Lets deal with it

--- a/pytomation/interfaces/hw_thermostat.py
+++ b/pytomation/interfaces/hw_thermostat.py
@@ -44,7 +44,7 @@ class HW_Thermostat(HAInterface):
         # We need to dial back how often we check the thermostat.. Lets not bombard it!
         if not self._iteration < self._poll_secs:
             self._iteration = 0
-            #check to see if there is anyting we need to read
+            #check to see if there is anything we need to read
             responses = self._interface.read('tstat')
             if len(responses) != 0:
                 for response in responses.split():

--- a/pytomation/interfaces/sparkio.py
+++ b/pytomation/interfaces/sparkio.py
@@ -37,7 +37,7 @@ class SparkIO(HAInterface):
         # We need to dial back how often we check the thermostat.. Lets not bombard it!
         if not self._iteration < self._poll_secs:
             self._iteration = 0
-            #check to see if there is anyting we need to read
+            #check to see if there is anything we need to read
             responses = self._interface.read('v1/:id/events')
             if len(responses) != 0:
                 for response in responses.split():

--- a/pytomation/interfaces/stargate.py
+++ b/pytomation/interfaces/stargate.py
@@ -68,7 +68,7 @@ class Stargate(HAInterface):
 	self._logger.error('Startgggg')
 
     def _readInterface(self, lastPacketHash):
-        #check to see if there is anyting we need to read
+        #check to see if there is anything we need to read
         responses = self._interface.read()
         if len(responses) != 0:
             for response in responses.split():
@@ -147,7 +147,7 @@ class Stargate(HAInterface):
     def _processRegister(self, response, lastPacketHash):
         foundCommandHash = None
 
-        #find our pending command in the list so we can say that we're done (if we are running in syncronous mode - if not well then the caller didn't care)
+        #find our pending command in the list so we can say that we're done (if we are running in synchronous mode - if not well then the caller didn't care)
         for (commandHash, commandDetails) in self._pendingCommandDetails.items():
             if commandDetails['modemCommand'] == self._modemCommands['read_register']:
                 #Looks like this is our command.  Lets deal with it

--- a/pytomation/interfaces/tomato.py
+++ b/pytomation/interfaces/tomato.py
@@ -35,7 +35,7 @@ class TomatoInterface(HAInterface):
         # We need to dial back how often we check the thermostat.. Lets not bombard it!
         if not self._iteration < self._poll_secs:
             self._iteration = 0
-            #check to see if there is anyting we need to read
+            #check to see if there is anything we need to read
 #             responses = self._interface.read('tstat')
 #             if len(responses) != 0:
 #                 for response in responses.split():

--- a/pytomation/interfaces/upb.py
+++ b/pytomation/interfaces/upb.py
@@ -195,7 +195,7 @@ class UPB(HAInterface):
                                              timeout=timeout)
 
     def _readInterface(self, lastPacketHash):
-        #check to see if there is anyting we need to read
+        #check to see if there is anything we need to read
         responses = self._interface.read()
         if len(responses) != 0:
             self._logger.debug("[UPB] Response>\n" + hex_dump(responses) + "\n")
@@ -221,7 +221,7 @@ class UPB(HAInterface):
     def _processUBP(self, response, lastPacketHash):
         foundCommandHash = None
 
-        #find our pending command in the list so we can say that we're done (if we are running in syncronous mode - if not well then the caller didn't care)
+        #find our pending command in the list so we can say that we're done (if we are running in synchronous mode - if not well then the caller didn't care)
         for (commandHash, commandDetails) in self._pendingCommandDetails.items():
             if commandDetails['modemCommand'] == self._modemCommands['send_upb']:
                 #Looks like this is our command.  Lets deal with it
@@ -246,7 +246,7 @@ class UPB(HAInterface):
     def _processRegister(self, response, lastPacketHash):
         foundCommandHash = None
 
-        #find our pending command in the list so we can say that we're done (if we are running in syncronous mode - if not well then the caller didn't care)
+        #find our pending command in the list so we can say that we're done (if we are running in synchronous mode - if not well then the caller didn't care)
         for (commandHash, commandDetails) in self._pendingCommandDetails.items():
             if commandDetails['modemCommand'] == self._modemCommands['read_register']:
                 #Looks like this is our command.  Lets deal with it

--- a/pytomation/utility/miranda.py
+++ b/pytomation/utility/miranda.py
@@ -8,7 +8,7 @@
 # Notes from Issac:
 # http://code.google.com/p/miranda-upnp/
 # Marks this file as GPL3 licensed by the author
-# I have made minor modificatinos to get it to work with the wemo
+# I have made minor modifications to get it to work with the wemo
 #
 ################################
 

--- a/pytomation_web/js/index.js
+++ b/pytomation_web/js/index.js
@@ -32,7 +32,7 @@ function init() {
     load_settings();
     if (currentTheme !== 'a') theme_changed(currentTheme);
     
-    //resize sliders, taking the hidden text box into accout
+    //resize sliders, taking the hidden text box into account
     $(window).resize(function() {
     clearTimeout(resizeTimer);
     resizeTimer = setTimeout(recalc_device_content_size, 200);
@@ -511,7 +511,7 @@ function reload_device_grid() {
         });
     if (style !== "compact") $(".command").click(on_device_command);
     
-    //resize slider, taking the hidden text box into accout 
+    //resize slider, taking the hidden text box into account 
     recalc_slider_size();
     
     //recalculate slider size when scrollbars appear (only in desktop version)

--- a/pytomation_web/js/jquery.mobile.iscrollview.js
+++ b/pytomation_web/js/jquery.mobile.iscrollview.js
@@ -271,7 +271,7 @@ function jqmIscrollviewRemoveLayerXYProps(e) {
   $window:            $(window),
   $wrapper:           [],  // The wrapper element
   $scroller:          [],  // The scroller element (first child of wrapper)
-  $scrollerContent:   [],  // Content of scroller, sandwitched between any pull-down/pull-up
+  $scrollerContent:   [],  // Content of scroller, sandwiched between any pull-down/pull-up
   $pullDown:          [],  // The pull-down element (if any)
   $pullUp:            [],  // The pull-up element (if any)
   $pullUpSpacer:      [],
@@ -1079,7 +1079,7 @@ function jqmIscrollviewRemoveLayerXYProps(e) {
 
   //-----------------------------------------------------------------------
   // Determine the box-sizing model of an element
-  // While jQuery normalizes box-sizing models when retriving geometry,
+  // While jQuery normalizes box-sizing models when retrieving geometry,
   // it doesn't consider it when SETTING geometry. So, this is useful when
   // setting geometry. (e.g. the height of the wrapper)
   //-----------------------------------------------------------------------
@@ -1126,7 +1126,7 @@ function jqmIscrollviewRemoveLayerXYProps(e) {
         // modifying it. This function is called before any removal of
         // padding, though. So, if $wrapper, use same calculation as for padding-box,
         // ignoring padding.
-        // (We actually don't call this for anything but $wrapper, but preseve
+        // (We actually don't call this for anything but $wrapper, but preserve
         // functionality in case we ever use it on another element)
           adjust = $elem.outerHeight($elem !== this.$wrapper ) - $elem.height();
           break;


### PR DESCRIPTION
There are small typos in:
- README.md
- pytomation/interfaces/arduino.py
- pytomation/interfaces/hw_thermostat.py
- pytomation/interfaces/sparkio.py
- pytomation/interfaces/stargate.py
- pytomation/interfaces/tomato.py
- pytomation/interfaces/upb.py
- pytomation/utility/miranda.py
- pytomation_web/js/index.js
- pytomation_web/js/jquery.mobile.iscrollview.js

Fixes:
- Should read `anything` rather than `anyting`.
- Should read `synchronous` rather than `syncronous`.
- Should read `account` rather than `accout`.
- Should read `sandwiched` rather than `sandwitched`.
- Should read `retrieving` rather than `retriving`.
- Should read `python` rather than `pythone`.
- Should read `preserve` rather than `preseve`.
- Should read `modifications` rather than `modificatinos`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md